### PR TITLE
handle XML filenames with extra suffix

### DIFF
--- a/preprocessing/importDataToDatabase.py
+++ b/preprocessing/importDataToDatabase.py
@@ -1,5 +1,6 @@
 import itertools
 from os.path import basename, splitext
+import re
 
 import pandas as pd
 from tqdm import tqdm
@@ -367,8 +368,15 @@ default_combined_list_transformer_by_table_name = {
 def get_combined_list_transformer(table_name):
   return default_combined_list_transformer_by_table_name.get(table_name)
 
+MANUSCRIPT_NO_REGEX = re.compile(r'^.*-(\d{3,})\D?.*$')
+
 def manuscript_number_to_no(x):
-  return x.split('-')[-1]
+  m = MANUSCRIPT_NO_REGEX.match(x)
+  if m:
+    return m.group(1)
+  else:
+    # fallback, return full manuscript reference instead
+    return x
 
 def version_key_to_no(x):
   return 1 + int(x.split('|')[-1])

--- a/preprocessing/importDataToDatabase_test.py
+++ b/preprocessing/importDataToDatabase_test.py
@@ -137,3 +137,21 @@ def test_with_missing_persons():
       set(df['version_id']) ==
       set([VERSION_ID1])
     )
+
+def test_with_manuscript_suffix():
+  with convert_files(['with-manuscript-suffix-00001-suffix.xml']) as db:
+    df = db.manuscript_version.read_frame().reset_index()
+    print(df)
+    assert (
+      set(df['version_id']) ==
+      set([VERSION_ID1])
+    )
+
+def test_with_invalid_manuscript_ref():
+  with convert_files(['with-invalid-manuscript-ref.xml']) as db:
+    df = db.manuscript_version.read_frame().reset_index()
+    print(df)
+    assert (
+      set(df['version_id']) ==
+      set(['with-invalid-manuscript-ref-1'])
+    )

--- a/preprocessing/test_data/with-invalid-manuscript-ref.xml
+++ b/preprocessing/test_data/with-invalid-manuscript-ref.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+  <manuscript>
+    <country>Country 1</country>
+    <production-data>
+      <production-data-doi>11.1234/pub.1234</production-data-doi>
+    </production-data>
+    <version>
+      <key>00001|0</key>
+      <abstract>This is quite abstract.</abstract>
+      <author-approval-date>2017-01-01T12:34:56Z</author-approval-date>
+      <decision>Reject Full Submission</decision>
+      <decision-date>2017-02-01T12:13:14Z</decision-date>
+      <ejp-decision>Reject</ejp-decision>
+      <is_resubmission>false</is_resubmission>
+      <manuscript-number>with-invalid-manuscript-ref</manuscript-number>
+      <manuscript-type>Research Article</manuscript-type>
+      <submission-date>2017-01-01T12:13:14Z</submission-date>
+      <title>Title 1</title>
+      <version-number>0</version-number>
+    </version>
+  </manuscript>
+</xml>

--- a/preprocessing/test_data/with-manuscript-suffix-00001-suffix.xml
+++ b/preprocessing/test_data/with-manuscript-suffix-00001-suffix.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+  <manuscript>
+    <country>Country 1</country>
+    <production-data>
+      <production-data-doi>11.1234/pub.1234</production-data-doi>
+    </production-data>
+    <version>
+      <key>00001|0</key>
+      <abstract>This is quite abstract.</abstract>
+      <author-approval-date>2017-01-01T12:34:56Z</author-approval-date>
+      <decision>Reject Full Submission</decision>
+      <decision-date>2017-02-01T12:13:14Z</decision-date>
+      <ejp-decision>Reject</ejp-decision>
+      <is_resubmission>false</is_resubmission>
+      <manuscript-number>regular-00001-suffix</manuscript-number>
+      <manuscript-type>Research Article</manuscript-type>
+      <submission-date>2017-01-01T12:13:14Z</submission-date>
+      <title>Title 1</title>
+      <version-number>0</version-number>
+    </version>
+  </manuscript>
+</xml>


### PR DESCRIPTION
Filenames usually end with the five digit manuscript number, but some had an extra suffix. This will extract the manuscript number even with a suffix (or leave the full filename as a reference).