### PR TITLE
Install newrelic Python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ scikit-learn==0.18.1
 scipy==0.19.1
 spacy==1.2.0
 bhtsne==0.1.9
+newrelic==2.90.0.75


### PR DESCRIPTION
The code shouldn't need dependencies towards this module, but it needs to be in the virtualenv to provide a binary that wraps Python adding instrumentation