### PR TITLE
Retain s3 file modified time

### DIFF
--- a/peerscout/preprocessing/convertUtils_test.py
+++ b/peerscout/preprocessing/convertUtils_test.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+import os
+from unittest.mock import Mock
+
+from .convertUtils import (
+  sort_relative_filenames_by_file_modified_time,
+  process_files_in_directory
+)
+
+FILE_1 = 'file1.dummy'
+FILE_2 = 'file2.dummy'
+
+def _create_dummy_file(parent, filename, dt):
+  p = parent.join(filename)
+  p.write('dummy')
+  os.utime(p, (dt.timestamp(), dt.timestamp()))
+  return p
+
+class TestSortRelativeFilenamesByFileModifiedTime:
+  def test_should_return_empty_list_if_filenames_are_empty(self, tmpdir):
+    assert sort_relative_filenames_by_file_modified_time(str(tmpdir), []) == []
+
+  def test_should_return_file_with_earlier_timestamp_first(self, tmpdir):
+    _create_dummy_file(tmpdir, FILE_1, datetime(2012, 1, 1))
+    _create_dummy_file(tmpdir, FILE_2, datetime(2011, 1, 1))
+
+    assert sort_relative_filenames_by_file_modified_time(
+      str(tmpdir), [FILE_1, FILE_2]
+    ) == [FILE_2, FILE_1]
+
+class TestProcessFilesInDirectory:
+  def test_should_return_file_with_earlier_timestamp_first(self, tmpdir):
+    _create_dummy_file(tmpdir, FILE_1, datetime(2012, 1, 1))
+    _create_dummy_file(tmpdir, FILE_2, datetime(2011, 1, 1))
+
+    process_file = Mock()
+    process_files_in_directory(str(tmpdir), process_file)
+    filename_args = [a[0][0] for a in process_file.call_args_list]
+    assert filename_args == [FILE_2, FILE_1]

--- a/peerscout/preprocessing/downloadFiles.py
+++ b/peerscout/preprocessing/downloadFiles.py
@@ -32,10 +32,10 @@ def download_objects(client, obj_list, download_path, downloaded_files=None):
         'downloading file %s (timestamp: %s)', remote_file, remote_file_timestamp
       )
       local_access_time = datetime.now().timestamp()
-      local_modifed_time = remote_file_timestamp.timestamp()
+      local_modified_time = remote_file_timestamp.timestamp()
 
       client.download_file(obj.bucket_name, remote_file, local_file)
-      os.utime(local_file, (local_access_time, local_modifed_time))
+      os.utime(local_file, (local_access_time, local_modified_time))
 
       if downloaded_files is not None:
         downloaded_files.append(remote_file)


### PR DESCRIPTION
resolves #192 

It is assumed that more recent xml dumps have a more up-to-date of the manuscripts even if the xml dump is backdated to re-deliver older manuscripts. Therefore it makes sense to process the files in order.

By ordering it by file modified time the behaviour would also be consistent when re-importing everything vs. importing incrementally.