### PR TITLE
Remove ci node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,13 +23,6 @@ elifePipeline({
         }
     }
 
-    stage 'Project tests', {
-        lock('peerscout--ci') {
-            builderDeployRevision 'peerscout--ci', commit
-            builderSmokeTests 'peerscout--ci', '/srv/peerscout'
-        }
-    }
-
     stage 'End2end', {
         lock('peerscout--end2end') {
             builderDeployRevision 'peerscout--end2end', commit


### PR DESCRIPTION
Projects in general execute the `ci` phase without a dedicated server but only a Jenkins `containers` node, so we shouldn't bother here, too.

Still this deploys to `end2end` all PRs, but doesn't use the whole environment, only the `peerscout--end2end` node.